### PR TITLE
Adding permissions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ This tool requires some readonly permissions from your AWS organization account.
 1. `sso:ListPermissionSetsProvisionedToAccount`
 1. `sso:DescribePermissionSet`
 
+You can view these in the application by running:
+
+```bash
+setlist --permissions
+```
+
 ### Basic Usage
 
 ```bash

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -23,7 +23,7 @@ const (
 	FlagProfile         string = "profile"
 	FlagMapping         string = "mapping"
 	FlagOutput          string = "output"
-  FlagPermissions     string = "permissions"
+	FlagPermissions     string = "permissions"
 	FlagStdout          string = "stdout"
 	FlagSSOFriendlyName string = "sso-friendly-name"
 )

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -23,6 +23,7 @@ const (
 	FlagProfile         string = "profile"
 	FlagMapping         string = "mapping"
 	FlagOutput          string = "output"
+  FlagPermissions     string = "permissions"
 	FlagStdout          string = "stdout"
 	FlagSSOFriendlyName string = "sso-friendly-name"
 )

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -8,4 +8,5 @@ var (
 	filename        string // Output filename
 	stdout          bool   // Flag to print output to stdout instead of a file
 	ssoFriendlyName string // Optional friendly name for the SSO instance
+  permissions     bool   // Flag to print the permissions needed and exit
 )

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -8,5 +8,5 @@ var (
 	filename        string // Output filename
 	stdout          bool   // Flag to print output to stdout instead of a file
 	ssoFriendlyName string // Optional friendly name for the SSO instance
-  permissions     bool   // Flag to print the permissions needed and exit
+	permissions     bool   // Flag to print the permissions needed and exit
 )

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -68,6 +68,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&mapping, FlagMapping, "m", "", "Comma-delimited Account Nickname Mapping (id=nickname)")
 	rootCmd.PersistentFlags().StringVarP(&filename, FlagOutput, "o", DEFAULT_FILENAME, "Where the AWS config file will be written")
 	rootCmd.PersistentFlags().BoolVar(&stdout, FlagStdout, false, "Specify this flag to write the config file to stdout instead of a file")
+	rootCmd.PersistentFlags().BoolVar(&permissions, FlagPermissions, false, "Specify this flag to print the required AWS permissions and then exit")
 	rootCmd.PersistentFlags().StringVar(&ssoFriendlyName, FlagSSOFriendlyName, "", "Use this instead of the identity store ID for the start URL")
 
 	rootCmd.MarkPersistentFlagRequired(FlagSSOSession)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,10 +71,11 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&permissions, FlagPermissions, false, "Specify this flag to print the required AWS permissions and then exit")
 	rootCmd.PersistentFlags().StringVar(&ssoFriendlyName, FlagSSOFriendlyName, "", "Use this instead of the identity store ID for the start URL")
 
-	rootCmd.MarkPersistentFlagRequired(FlagSSOSession)
-	rootCmd.MarkPersistentFlagRequired(FlagSSORegion)
-
 	rootCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if permissions {
+			return nil
+		}
+
 		return validateRequiredFlags(cmd)
 	}
 }

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -30,6 +30,14 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 	var cfg aws.Config
 	var err error
 
+  if permissions {
+    fmt.Println("organizations:ListAccounts")
+    fmt.Println("sso:ListInstances")
+    fmt.Println("sso:ListPermissionSetsProvisionedToAccount")
+    fmt.Println("sso:DescribePermissionSet")
+    return nil
+  }
+
 	// check if a profile is specified
 	if profile != "" {
 		// create a config with the specified profile

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -30,13 +30,12 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 	var cfg aws.Config
 	var err error
 
-  if permissions {
-    fmt.Println("organizations:ListAccounts")
-    fmt.Println("sso:ListInstances")
-    fmt.Println("sso:ListPermissionSetsProvisionedToAccount")
-    fmt.Println("sso:DescribePermissionSet")
-    return nil
-  }
+	if permissions {
+		for _, p := range core.ListPermissionsRequired() {
+			fmt.Println(p)
+		}
+		return nil
+	}
 
 	// check if a profile is specified
 	if profile != "" {

--- a/permissions.go
+++ b/permissions.go
@@ -1,0 +1,10 @@
+package setlist
+
+func ListPermissionsRequired() []string {
+	return []string{
+		"organizations:ListAccounts",
+		"sso:ListInstances",
+		"sso:ListPermissionSetsProvisionedToAccount",
+		"sso:DescribePermissionSet",
+	}
+}


### PR DESCRIPTION
Adding a new flag called `--permissions` that simply prints out the AWS permissions required to use this application.