### PR TITLE
Updating Go version to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.1'
+          go-version: '1.24'
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scottbrown/setlist
 
-go 1.22
+go 1.24
 
 toolchain go1.24.0
 


### PR DESCRIPTION
This change updates the Go version used by the app and all Github Action workflows to the latest version, 1.24.