### PR TITLE
Closes #227 by adding a list-accounts feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ By supplying a `--mapping` flag with a comma-delimited list of key=value pairs c
 |--output|-o|Output file path (default: ./aws.config)|No|
 |--stdout||Write config to stdout instead of a file|No|
 |--sso-friendly-name||Alternative name for the SSO start URL|No|
+|--list-accounts|Lists all available AWS accounts|
 
 ## Generated Config Format
 

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -27,6 +27,7 @@ const (
 	FlagStdout          string = "stdout"
 	FlagSSOFriendlyName string = "sso-friendly-name"
 	FlagCheckUpdate     string = "check-update"
+	FlagListAccounts    string = "list-accounts"
 )
 
 // Default output filename if no filename is specified

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -10,4 +10,5 @@ var (
 	ssoFriendlyName string // Optional friendly name for the SSO instance
 	permissions     bool   // Flag to print the permissions needed and exit
 	checkUpdate     bool   // Flag to check if an update is available
+	listAccounts    bool   // Only list AWS accounts found
 )

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,9 +71,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&permissions, FlagPermissions, false, "Specify this flag to print the required AWS permissions and then exit")
 	rootCmd.PersistentFlags().StringVar(&ssoFriendlyName, FlagSSOFriendlyName, "", "Use this instead of the identity store ID for the start URL")
 	rootCmd.PersistentFlags().BoolVar(&checkUpdate, FlagCheckUpdate, false, "Check if a newer version of the tool is available")
+	rootCmd.PersistentFlags().BoolVar(&listAccounts, FlagListAccounts, false, "List all available AWS accounts")
 
 	rootCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if permissions || checkUpdate {
+		if permissions || checkUpdate || listAccounts {
 			return nil
 		}
 

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -93,6 +93,13 @@ func handleRoot(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid mapping format: %w", err)
 	}
 
+	if listAccounts {
+		for _, a := range accounts {
+			fmt.Printf("%s\t%s\n", *a.Id, *a.Name)
+		}
+		return nil
+	}
+
 	configFile := core.ConfigFile{
 		SessionName:     ssoSession,
 		IdentityStoreId: *instance.IdentityStoreId,


### PR DESCRIPTION
Adds a new feature that allows the user to list all available AWS accounts without generating a configuration file.