### PR TITLE
Refactoring for ease of reading

### DIFF
--- a/cmd/handle_check_update.go
+++ b/cmd/handle_check_update.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scottbrown/setlist"
+)
+
+// handleCheckUpdate checks for updates and displays the results
+func handleCheckUpdate(ctx context.Context) error {
+	info, err := setlist.CheckForUpdates(ctx)
+	if err != nil {
+		return fmt.Errorf("error checking for updates: %w", err)
+	}
+
+	if info == nil {
+		fmt.Printf("You're running the latest version (v%s)\n", setlist.VERSION)
+	} else {
+		fmt.Printf("A new version is available!\n")
+		fmt.Printf("Current version: v%s\n", info.CurrentVersion)
+		fmt.Printf("Latest version:  %s (released %s)\n",
+			info.LatestVersion,
+			info.ReleaseDate.Format("2006-01-02"))
+		fmt.Printf("Download URL:    %s\n", info.ReleaseURL)
+	}
+
+	return nil
+}

--- a/cmd/handle_list_permissions.go
+++ b/cmd/handle_list_permissions.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/scottbrown/setlist"
+)
+
+// handleListPermissions lists all required permissions
+func handleListPermissions() error {
+	for _, p := range setlist.ListPermissionsRequired() {
+		fmt.Println(p)
+	}
+	return nil
+}


### PR DESCRIPTION
This change refactors the `handleRoot` function because it was getting too lengthy and difficult to read. It also did not allow for testing of individual components.