### PR TITLE
Adding unit tests

### DIFF
--- a/permissions_test.go
+++ b/permissions_test.go
@@ -1,0 +1,13 @@
+package setlist
+
+import (
+	"testing"
+)
+
+func TestListPermissions(t *testing.T) {
+	result := ListPermissionsRequired()
+
+	if len(result) == 0 {
+		t.Errorf("ListPermissionsRequired() must have at least one permission")
+	}
+}

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,53 @@
+package setlist
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+// TestGenerateTimestamp verifies the timestamp format
+func TestGenerateTimestamp(t *testing.T) {
+	// The expected format is "2006-01-02T15:04:05 UTC"
+	expectedPattern := `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} UTC$`
+
+	result := generateTimestamp()
+
+	matched, err := regexp.MatchString(expectedPattern, result)
+	if err != nil {
+		t.Fatalf("Error matching regex pattern: %v", err)
+	}
+
+	if !matched {
+		t.Errorf("generateTimestamp() = %q, does not match expected pattern %q",
+			result, expectedPattern)
+	}
+}
+
+// TestTimestampIsUTC verifies that the timestamp is in UTC
+func TestTimestampIsUTC(t *testing.T) {
+	// Parse the generated timestamp
+	result := generateTimestamp()
+
+	// The timestamp should end with " UTC"
+	if len(result) < 4 || result[len(result)-3:] != "UTC" {
+		t.Errorf("generateTimestamp() = %q, should end with 'UTC'", result)
+	}
+
+	// The actual time should be within a reasonable range of current time
+	timestamp, err := time.Parse("2006-01-02T15:04:05 MST", result)
+	if err != nil {
+		t.Fatalf("Failed to parse timestamp %q: %v", result, err)
+	}
+
+	// Check that the timestamp is within 5 seconds of the current time
+	now := time.Now().UTC()
+	diff := now.Sub(timestamp)
+	if diff < 0 {
+		diff = -diff
+	}
+
+	if diff > 5*time.Second {
+		t.Errorf("Timestamp difference too large: %v", diff)
+	}
+}


### PR DESCRIPTION
This pull request introduces new tests to the `setlist` package to verify the functionality of permission listing and timestamp generation. The most important changes include adding tests for listing permissions and verifying the format and correctness of generated timestamps.

### New Tests Added:

* [`permissions_test.go`](diffhunk://#diff-639edccdc8e7dcc68386e5998015fa1730d3c32ac092dbe97644c30fb2600d96R1-R13): Added a test function `TestListPermissions` to ensure that `ListPermissionsRequired` returns at least one permission.

* `time_test.go`: 
  * Added a test function `TestGenerateTimestamp` to verify that the generated timestamp matches the expected format `2006-01-02T15:04:05 UTC`.
  * Added a test function `TestTimestampIsUTC` to check that the generated timestamp is in UTC and within a reasonable range of the current time.