### PR TITLE
Adding AWS account ID validation.  Closes #229.

### DIFF
--- a/nickname.go
+++ b/nickname.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+var accountIdPattern = regexp.MustCompile("^[0-9]{12}$")
+
 // ParseNicknameMapping parses a comma-delimited string of account ID to nickname
 // mappings into a map. The expected format is "accountID1=nickname1,accountID2=nickname2".
 // This enables users to reference AWS accounts by friendly names rather than
@@ -36,8 +38,7 @@ func ParseNicknameMapping(mapping string) (map[string]string, error) {
 			return nil, fmt.Errorf("empty account ID in mapping entry %d", i+1)
 		}
 
-		match, _ := regexp.MatchString("^[0-9]{12}$", accountID)
-		if !match {
+		if !accountIdPattern.MatchString(accountID) {
 			return nil, fmt.Errorf("invalid account ID in mapping entry %d", i+1)
 		}
 

--- a/nickname.go
+++ b/nickname.go
@@ -2,6 +2,7 @@ package setlist
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -33,6 +34,11 @@ func ParseNicknameMapping(mapping string) (map[string]string, error) {
 
 		if accountID == "" {
 			return nil, fmt.Errorf("empty account ID in mapping entry %d", i+1)
+		}
+
+		match, _ := regexp.MatchString("^[0-9]{12}$", accountID)
+		if !match {
+			return nil, fmt.Errorf("invalid account ID in mapping entry %d", i+1)
 		}
 
 		if nickname == "" {

--- a/nickname_test.go
+++ b/nickname_test.go
@@ -14,10 +14,10 @@ func TestParseNicknameMapping(t *testing.T) {
 	}{
 		{
 			"knowngood",
-			"01234=foo,9876=bar",
+			"123456789012=foo,123456789013=bar",
 			map[string]string{
-				"01234": "foo",
-				"9876":  "bar",
+				"123456789012": "foo",
+				"123456789013": "bar",
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestParseNicknameMappingErrors(t *testing.T) {
 		},
 		{
 			"valid mapping",
-			"12345=prod,67890=dev",
+			"123456789012=prod,123456789013=dev",
 			false,
 			"",
 		},
@@ -72,7 +72,7 @@ func TestParseNicknameMappingErrors(t *testing.T) {
 		},
 		{
 			"empty nickname",
-			"12345=",
+			"123456789012=",
 			true,
 			"empty nickname",
 		},
@@ -84,9 +84,27 @@ func TestParseNicknameMappingErrors(t *testing.T) {
 		},
 		{
 			"mixed valid and invalid",
-			"12345=prod,invalid",
+			"123456789012=prod,invalid",
 			true,
 			"invalid nickname mapping format",
+		},
+		{
+			"too short account id",
+			"123=prod,1234567789012=stg",
+			true,
+			"invalid account ID in mapping entry",
+		},
+		{
+			"too long account id",
+			"1234567890123=prod,1234567789012=stg",
+			true,
+			"invalid account ID in mapping entry",
+		},
+		{
+			"alphanumeric account id",
+			"123a45789012=prod,1234567789012=stg",
+			true,
+			"invalid account ID in mapping entry",
 		},
 	}
 


### PR DESCRIPTION
This pull request includes changes to the `nickname.go` file to add validation for account IDs and updates to the corresponding tests in `nickname_test.go` to ensure the new validation logic is working correctly.

### Validation added for account IDs:

* [`nickname.go`](diffhunk://#diff-79cef190ff004923c12f63c11b8943eb70c33b8edda895e0c979f9771b2b8feeR39-R43): Added a regular expression check to ensure account IDs are exactly 12 digits long in the `ParseNicknameMapping` function.

### Test updates:

* [`nickname_test.go`](diffhunk://#diff-4998f56340843b59166f2344e3c1c32c0e2c0f3959df4d42eac3e952ca262b11L17-R20): Updated test cases in `TestParseNicknameMapping` to use 12-digit account IDs.
* [`nickname_test.go`](diffhunk://#diff-4998f56340843b59166f2344e3c1c32c0e2c0f3959df4d42eac3e952ca262b11L57-R57): Updated test cases in `TestParseNicknameMappingErrors` to use 12-digit account IDs and added new test cases to check for invalid account IDs (too short, too long, and alphanumeric). [[1]](diffhunk://#diff-4998f56340843b59166f2344e3c1c32c0e2c0f3959df4d42eac3e952ca262b11L57-R57) [[2]](diffhunk://#diff-4998f56340843b59166f2344e3c1c32c0e2c0f3959df4d42eac3e952ca262b11L75-R75) [[3]](diffhunk://#diff-4998f56340843b59166f2344e3c1c32c0e2c0f3959df4d42eac3e952ca262b11L87-R108)