### PR TITLE
Adding the ability to filter the account list. Closes #225

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -28,6 +28,8 @@ const (
 	FlagSSOFriendlyName string = "sso-friendly-name"
 	FlagCheckUpdate     string = "check-update"
 	FlagListAccounts    string = "list-accounts"
+	FlagIncludeAccounts string = "include-accounts"
+	FlagExcludeAccounts string = "exclude-accounts"
 )
 
 // Default output filename if no filename is specified

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -11,4 +11,6 @@ var (
 	permissions     bool   // Flag to print the permissions needed and exit
 	checkUpdate     bool   // Flag to check if an update is available
 	listAccounts    bool   // Only list AWS accounts found
+	includeAccounts string // Comma-separated list of accounts to include
+	excludeAccounts string // Comma-separated list of accounts to exclude
 )

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,6 +72,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&ssoFriendlyName, FlagSSOFriendlyName, "", "Use this instead of the identity store ID for the start URL")
 	rootCmd.PersistentFlags().BoolVar(&checkUpdate, FlagCheckUpdate, false, "Check if a newer version of the tool is available")
 	rootCmd.PersistentFlags().BoolVar(&listAccounts, FlagListAccounts, false, "List all available AWS accounts")
+	rootCmd.PersistentFlags().StringVarP(&includeAccounts, FlagIncludeAccounts, "", "", "Include only these comma-separated accounts")
+	rootCmd.PersistentFlags().StringVarP(&excludeAccounts, FlagExcludeAccounts, "", "", "Exclude these comma-separated accounts")
 
 	rootCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if permissions || checkUpdate || listAccounts {

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/scottbrown/setlist"
 
@@ -130,9 +131,20 @@ func buildProfiles(
 ) ([]setlist.Profile, error) {
 	profiles := []setlist.Profile{}
 
+	includedAccounts := buildIncludedAccounts()
+	excludedAccounts := buildExcludedAccounts()
+
 	for _, account := range accounts {
 		if account.Id == nil {
 			fmt.Fprintf(os.Stderr, "Warning: Found account with nil ID, skipping\n")
+			continue
+		}
+
+		if !includedAccounts.Contains(*account.Id) {
+			continue
+		}
+
+		if excludedAccounts.Contains(*account.Id) {
 			continue
 		}
 
@@ -207,4 +219,24 @@ func displayAccounts(accounts []orgtypes.Account) error {
 	}
 
 	return nil
+}
+
+type AccountsFilter []string
+
+func buildIncludedAccounts() AccountsFilter {
+	return strings.Split(includeAccounts, ",")
+}
+
+func buildExcludedAccounts() AccountsFilter {
+	return strings.Split(excludeAccounts, ",")
+}
+
+func (a AccountsFilter) Contains(id string) bool {
+	for _, i := range a {
+		if i == id {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This pull request introduces functionality to include or exclude specific AWS accounts using new command-line flags. The changes span multiple files to implement this feature.

New feature implementation:

* [`cmd/constants.go`](diffhunk://#diff-f323d7d444ff7d9e6f1998b33b6d6b06694203ce230fe114a926252b23e552f4R31-R32): Added new flags `FlagIncludeAccounts` and `FlagExcludeAccounts` for including and excluding accounts.
* [`cmd/flags.go`](diffhunk://#diff-e231d920accff9e68d1581fc082513cda53631f2a312c9005448288b29dd08a3R14-R15): Introduced new variables `includeAccounts` and `excludeAccounts` to store comma-separated lists of accounts to include or exclude.
* [`cmd/init.go`](diffhunk://#diff-345cd3beb7d905a8bef99d83e99c62678bfd5101a26d30104ecc9320602072acR75-R76): Registered the new flags `includeAccounts` and `excludeAccounts` with the command-line interface.

Account filtering logic:

* [`cmd/rootCmd.go`](diffhunk://#diff-24e453e93b78ecd5f63d329c629ad062253997275453582311340b8f5f674c36R7): Added imports for `strings` to handle account filtering.
* [`cmd/rootCmd.go`](diffhunk://#diff-24e453e93b78ecd5f63d329c629ad062253997275453582311340b8f5f674c36R134-R150): Implemented `buildIncludedAccounts` and `buildExcludedAccounts` functions to create filters from the provided account lists and applied these filters in the `buildProfiles` function to include or exclude accounts accordingly. [[1]](diffhunk://#diff-24e453e93b78ecd5f63d329c629ad062253997275453582311340b8f5f674c36R134-R150) [[2]](diffhunk://#diff-24e453e93b78ecd5f63d329c629ad062253997275453582311340b8f5f674c36R223-R242)